### PR TITLE
Add day batch size config option.

### DIFF
--- a/tap_awin/streams.py
+++ b/tap_awin/streams.py
@@ -79,7 +79,7 @@ class TransactionsStream(AwinStream):
             th.Property("amount", th.NumberType),
             th.Property("currency", th.StringType),
         )),
-        th.Property("ipHash", th.IntegerType),
+        th.Property("ipHash", th.StringType),
         th.Property("customerCountry", th.StringType),
         th.Property("clickRefs", th.ObjectType(
             th.Property("clickRef", th.StringType),

--- a/tap_awin/streams.py
+++ b/tap_awin/streams.py
@@ -163,20 +163,27 @@ class TransactionsStream(AwinStream):
         else:
             start_date = self.get_starting_timestamp(context) - datetime.timedelta(days=self.config.get("lookback_days"))
         today = datetime.datetime.now(tz=start_date.tzinfo)
-        end_date = min(start_date + datetime.timedelta(days=1), today)
-        params = {
-            'startDate': datetime.datetime.strftime(
+        batch_size_days = self.config.get("request_batch_size_days")
+        if batch_size_days > 31:
+            self.logger.info(f"Maximum day batch size is 31 days. Falling back to default batch size of 1 day.")
+            batch_size_days = 1
+        end_date = min(start_date + datetime.timedelta(days=batch_size_days), today)
+        formatted_start_date = datetime.datetime.strftime(
                 start_date.replace(hour=0, minute=0, second=0, microsecond=0),
                 TIMESTAMP_FORMAT
-            ),
-            'endDate': datetime.datetime.strftime(
+            )
+        formatted_end_date = datetime.datetime.strftime(
                 end_date.replace(hour=0, minute=0, second=0, microsecond=0),
                 TIMESTAMP_FORMAT
-            ),
+            )
+        params = {
+            'startDate': formatted_start_date,
+            'endDate': formatted_end_date,
             'timezone': self.config.get("timezone"),
             'dateType': 'transaction',
             'accessToken': self.config.get("api_token")
         }
+        self.logger.info(f"Requesting transaction data from {formatted_start_date} to {formatted_end_date}.")
         return params
 
     def get_next_page_token(

--- a/tap_awin/tap.py
+++ b/tap_awin/tap.py
@@ -49,6 +49,13 @@ class TapAwin(Tap):
             default=30,
             description="Number of days to lookback to re-sync transactions"
         ),
+        th.Property(
+            "request_batch_size_days",
+            th.IntegerType,
+            description="Number of days to batch in a single request. Maximum is 31.",
+            default=1
+        ),
+            
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:


### PR DESCRIPTION
## Problem

We were often seeing 429 rate limit errors with our Awin requests, due to the 1-day batch requests. With our large lookback window, this resulted in many rapid requests, and we hit the 20 request per minute limit from the Awin API.
See more about the rate limit [here](https://success.awin.com/s/article/Publisher-API-GET-transactions-list?language=en_US).

## Solution

Added a config option for batch size (in days). This new config option defaults to 1, to avoid breaking any existing implementations, but gives us the flexibility to increase our batch size up to the limit (31 days).

Also added some logging to indicate what date range is being requested.
## Testing

See an example of 30-day batch requests taking place here:
<img width="982" alt="image" src="https://github.com/GtheSheep/tap-awin/assets/35661883/dcffab28-0d80-4a17-b83c-ad3349fbfe43">